### PR TITLE
Enforce array for some XML nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickxml_to_serde"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Alec Troemel <alec@mirusresearch.com>", "Max Voskob <max@onebro.me>"]
 description = "Convert between XML JSON using quickxml and serde"
 repository = "https://github.com/AlecTroemel/quickxml_to_serde"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ let config = Config::new_with_defaults()
         .add_json_type_override("/a/b", JsonArray::Always(JsonType::AlwaysString));
 ```
 
-**Empty XML nodes cannot be converted to empty arrays**. For example, conversion of `<a><b /></a>` depends on `NullValue` setting.
+Conversion of empty XML nodes like `<a><b /></a>` depends on `NullValue` setting. For example,
 ```rust
 let config = Config::new_with_custom_values(false, "@", "#text", NullValue::Ignore)
         .add_json_type_override("/a/b", JsonArray::Always(JsonType::Infer));

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ Sample XML document:
 ```
 Configuration to make attribute `attr1="007"` always come out as a JSON string:
 ```rust
-let conf = Config::new_with_defaults().add_json_type_override("/a/@attr1", JsonType::AlwaysString);
+let conf = Config::new_with_defaults().add_json_type_override("/a/@attr1", JsonArray::Infer(JsonType::AlwaysString));
 ```
 Configuration to make both attributes and the text node of `<b />` always come out as a JSON string:
 ```rust
 let conf = Config::new_with_defaults()
-          .add_json_type_override("/a/@attr1", JsonType::AlwaysString)
-          .add_json_type_override("/a/b/@attr1", JsonType::AlwaysString)
-          .add_json_type_override("/a/b", JsonType::AlwaysString);
+          .add_json_type_override("/a/@attr1", JsonArray::Infer(JsonType::AlwaysString))
+          .add_json_type_override("/a/b/@attr1", JsonArray::Infer(JsonType::AlwaysString))
+          .add_json_type_override("/a/b", JsonArray::Infer(JsonType::AlwaysString));
 ```
 
 #### Boolean
@@ -86,8 +86,17 @@ The only two [valid boolean values in JSON](https://json-schema.org/understandin
 
 ```rust
 let conf = Config::new_with_defaults()
-        .add_json_type_override("/a/b", JsonType::Bool(vec!["True","true","1","yes"]));
+        .add_json_type_override("/a/b", JsonArray::Infer(JsonType::Bool(vec!["True","true","1","yes"])));
 ```
+
+#### Arrays
+
+Multiple nodes with the same name are automatically converted into a JSON array. For example,
+`<a><b>1</b><b>2</b></a>` is converted into `"a": { "b": [1,2] }`, but a single element as in `<a><b>1</b></a>`
+is converted into a scalar value like `"a": { "b": 1 }`. You can use `JsonArray::Always(JsonType::Infer)` to create a JSON array regardless of the number of elements so that `<a><b>1</b></a>` becomes `"a": { "b": [1] }`.
+
+`JsonArray::Always()` and `JsonArray::Infer()` can specify what underlying JSON type should be used, e.g. `Infer`, `AlwaysString` or `Bool()`.
+
 
 See embedded docs for `Config` struct and its members for more details. 
 
@@ -169,8 +178,8 @@ is converted into
 
 #### Additional info and examples
 
-See `mod tests` inside [lib.rs](src/lib.rs) for more usage examples.
+See [tests.rs](src/tests.rs) for more usage examples.
 
 ## Edge cases
 
-XML and JSON are not directly compatible for 1:1 conversion without additional hints to the converter. Feel free to post an issue if you come across any incorrect conversion.
+XML and JSON are not directly compatible for 1:1 conversion without additional hints to the converter. Please, post an issue if you come across any incorrect conversion.

--- a/examples/json_types.rs
+++ b/examples/json_types.rs
@@ -1,6 +1,6 @@
 extern crate quickxml_to_serde;
 #[cfg(feature = "json_types")]
-use quickxml_to_serde::{xml_string_to_json, Config, JsonType};
+use quickxml_to_serde::{xml_string_to_json, Config, JsonArray, JsonType};
 
 #[cfg(feature = "json_types")]
 fn main() {
@@ -8,8 +8,8 @@ fn main() {
 
     // custom config values for 1 attribute and a text node
     let conf = Config::new_with_defaults()
-        .add_json_type_override("/a/b/@attr1", JsonType::AlwaysString)
-        .add_json_type_override("/a/b", JsonType::AlwaysString);
+        .add_json_type_override("/a/b/@attr1", JsonArray::Infer(JsonType::AlwaysString))
+        .add_json_type_override("/a/b", JsonArray::Infer(JsonType::AlwaysString));
     let json = xml_string_to_json(String::from(xml), &conf);
     println!("{}", json.expect("Malformed XML").to_string());
 }


### PR DESCRIPTION
Closes #13 

## Changes

1. Bumped the version to 0.4.3
2. Updated ReadMe with examples and explanations
3. Added built-in tests

## Breaking changes

* Added `JsonArray` enum to specify if a node should always be an array

Specifying the JSON type is a 2-level enum. 

It used to be just `JsonType::AlwaysString`. Now the type has to be wrapped into `JsonArray` like this: `JsonArray::Infer(JsonType::AlwaysString))`

**Before**:
```rust
let conf = Config::new_with_defaults()
        .add_json_type_override("/a/@attr1", JsonType::AlwaysString)
        .add_json_type_override("/a/b/@attr1", JsonType::AlwaysString)
        .add_json_type_override("/a/b", JsonType::AlwaysString);
```

**After**:
```rust
    let conf = Config::new_with_defaults()
        .add_json_type_override("/a/@attr1", JsonArray::Infer(JsonType::AlwaysString))
        .add_json_type_override("/a/b/@attr1", JsonArray::Infer(JsonType::AlwaysString))
        .add_json_type_override("/a/b", JsonArray::Infer(JsonType::AlwaysString));
```

It's not a big change. I fixed the existing code with a single global search and replace.

## Testing

Apart from the built-in tests it has been running in PROD for a couple of weeks.

@AlecTroemel , Alec, please, take a look if you have a minute.