### PR TITLE
Remove `quick-xml` warning by updating dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickxml_to_serde"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Alec Troemel <alec@mirusresearch.com>", "Max Voskob <max@onebro.me>"]
 description = "Convert between XML JSON using quickxml and serde"
 repository = "https://github.com/AlecTroemel/quickxml_to_serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-minidom = "0.12"
-regex = "1.8.3"
+minidom = "0.15"
+regex = "1.10.4"
 
 [features]
 json_types = [] # Enable to enforce fixed JSON data types for certain XML nodes


### PR DESCRIPTION
Hello!

This PR updates the dependencies in `Cargo.toml`, specifically `minidom v0.12 -> v0.15`. I encountered the following warning when compiling on version `0.6.0`:

```
$ cargo run
    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.54s
warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.17.2
```

I tried updating the dependencies and it seems that newer version of minidom have dropped quick-xml entirely.
```
├── minidom v0.12.0
│   └── quick-xml v0.17.2
│       └── memchr v2.7.2

...

├── minidom v0.15.2
│   └── rxml v0.9.1
│       ├── bytes v1.6.0
│       ├── rxml_validation v0.9.1
│       └── smartstring v1.0.1
│           └── static_assertions v1.1.0
```
